### PR TITLE
Replace deprecated time.clock

### DIFF
--- a/game/scenes.py
+++ b/game/scenes.py
@@ -907,8 +907,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.perf_counter()
+        while self.queue and time.perf_counter() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
Hi,

Here is a small patch to replace `time.clock` which is not anymore part of Python 3.8.

In side note, `time.clock` is deprecated since python 3.3, so it should be safe.

Regards,